### PR TITLE
Allow to override the column and filter if grid defined in parent grid

### DIFF
--- a/lib/datagrid/columns.rb
+++ b/lib/datagrid/columns.rb
@@ -204,6 +204,9 @@ module Datagrid
         block ||= lambda do |model|
           model.send(name)
         end
+
+        remove_defined_column(columns, name, options)
+
         position = Datagrid::Utils.extract_position_from_options(columns, options)
         column = Datagrid::Columns::Column.new(
           self, name, query, default_column_options.merge(options), &block
@@ -215,6 +218,13 @@ module Datagrid
         return name if name.is_a?(Datagrid::Columns::Column)
         columns.find do |col|
           col.name.to_sym == name.to_sym
+        end
+      end
+
+      def remove_defined_column(columns, name, options)
+        existed_column = find_column_by_name(columns, name)
+        if existed_column.present? && existed_column.options[:header] == options[:header]
+          columns.delete(existed_column)
         end
       end
 

--- a/lib/datagrid/filters.rb
+++ b/lib/datagrid/filters.rb
@@ -101,6 +101,8 @@ module Datagrid
         klass = type.is_a?(Class) ? type : FILTER_TYPES[type]
         raise ConfigurationError, "filter class #{type.inspect} not found" unless klass
 
+        remove_defined_filter(name)
+
         position = Datagrid::Utils.extract_position_from_options(filters_array, options)
         filter = klass.new(self, name, options, &block)
         filters_array.insert(position, filter)
@@ -120,6 +122,11 @@ module Datagrid
 
       def filters
         filters_array
+      end
+
+      def remove_defined_filter(name)
+        existed_filter = filter_by_name(name)
+        filters_array.delete(existed_filter) if existed_filter.present?
       end
 
       protected


### PR DESCRIPTION
Issue: columns and filters will be duplicated on child grid instance if the parent grid class already defined with same name. 
So we will replace the old one by new column or filter defined